### PR TITLE
Support domains with Infinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 This package aims to be a lightweight, faster-loading alternative to the excellent [Integrals.jl](https://github.com/SciML/Integrals.jl) from the SciML ecosystem. IntegrationInterface.jl offers an interface to perform n-dimensional numerical integrals of scalars, arrays or more general objects, over a domain $D$.
 
-$$J(\text{args}...; \text{params}...) = \int_{D(\text{args}...)} d^n x f(\boldsymbol x..., \text{args}...; \text{params}...)$$
+$$J(\text{args}...; \text{params}...) = \int_{D(\text{args}...; \text{params}...)} d^n x f(\boldsymbol x..., \text{args}...; \text{params}...)$$
 
 The general interface reads
 ```julia
-julia> J = integral(f, domain; solver::AbstractBackend = Backend.QuadGK(), result = missing)
+julia> J = integral(f, domain; solver::AbstractBackend = default_solver(domain), result = missing)
 ```
 This produces an `J::Integral` object. Possible domains are produced with `Domain.Segment` or`Domain.Box`. Here `Backend` and `Domain` are exported submodules of `IntegrationInterface`. Functions of `args` can be passed to the constructor of a domain to make it depend on arguments passed to `J`.
 
@@ -41,9 +41,9 @@ julia> J()
 
 As shown above, the integration is actually performed by backend packages that may be loaded as needed. Currently supported packages (weak dependencies) and corresponding solvers in `IntegralSolvers` are
 
-- QuadGK.jl: `Backend.QuadGK(; opts...)` (calls `quadgk` and `quadgk!`, for 1D integrals over a `Domain.Segment`)
-- Cubature.jl: `Backend.Cubature(; opts...)` (calls `hcubature`, for n-D integrals over a `Domain.Box`)
-- HCubature.jl:  `Backend.HCubature(; opts...)` (calls `hcubature`, for n-D integrals in a `Domain.Box`)
+- QuadGK.jl: `Backend.QuadGK(; opts...)` (calls `quadgk` and `quadgk!`, default for `Domain.Segment` domains)
+- HCubature.jl:  `Backend.HCubature(; opts...)` (calls `hcubature`, default for `Domain.Box` domains)
+- Cubature.jl: `Backend.Cubature(; opts...)` (calls `hcubature`)
 
 We also provide a `Backend.Quadrature((nodes, weights))` solver that can be used with the FastGaussQuadrature.jl package that computes nodes and weights for a 1D integral in the [-1, 1] integration domain. Nodes and weights are then scaled appropriately to the domain provided
 ```julia
@@ -127,3 +127,19 @@ julia> J()
 
 ```
 where we have passed a function to the `Domain.Segment` instead of the segment nodes.
+
+Some backends support using `Inf` to express unbounded domains. If that is not supported, we provide `Infinity(point::Number)` that can be used instead. It represents an unbounded ray passing though `point` (which may be Real or not). These `Infinite` bounds are dealt with using an appropriate change of variables that takes `point` into account. As an example, consider a 2D half-plane `D = Domain.Box((; σ = 1) -> ((0, -Infinity(σ)), (Infinity(σ), Infinity(σ))))`. Note that it is a `Domain.Functional` object that depends on `σ`. We can integrate a Gaussian over `D`, which gives `π` for `σ = 1`
+
+```julia
+julia> f(x, y; σ = 1) = exp(-0.5*(x^2+y^2)/σ^2);
+
+julia> J = integral(f, D)
+Integral
+  Mutating   : false
+  Domain     : Functional{Box}
+  Solver     : HCubature
+  Integrand  : f
+
+julia> J(; σ = 1)
+3.141592652846476
+```

--- a/ext/IntegrationInterfaceCubatureExt.jl
+++ b/ext/IntegrationInterfaceCubatureExt.jl
@@ -4,20 +4,25 @@ using Cubature
 using IntegrationInterface
 import IntegrationInterface as II
 
-# supported domains (no need to deal with Domain.Functional here)
-II.check_domain_solver(::Type{<:Union{Domain.Box}}, ::Backend.Cubature) = nothing
+II.convert_domain(s::Domain.Box, ::Backend.Cubature) = I.convert_domain_generic(s)
 
-II.convert_domain(s::Domain.Box, ::Backend.Cubature) = (s.mins, s.maxs)
+# Scalar case is easy
+II.convert_integrand(i::II.Integral{Missing,<:Backend.Cubature}, domain, args; params...) =
+    II.convert_integrand_generic(i, domain, args; params...)
 
-(s::Backend.Cubature)(f, domain, ::Missing, args; params...) =
-	hcubature(point -> f(point..., args...; params...), II.convert_domain(domain, s, args)...; s.opts...) |> first
+# Cubature only understands Scalar or Vector{Float32} arguments. We must serialize/deserialize
+function II.convert_integrand(i::Integral{<:Any,<:Backend.Cubature}, d, args; params...)
+    f! = II.integrand(i)
+    fd!(t, out) = jacobian(t, d) * f!(II.deserialize_array(t, out), change_of_variables(t, d)..., args...; params...)
+    return fd!
+end
+
+(s::Backend.Cubature)(f, domain, ::Missing) = hcubature(f, domain...; s.opts...) |> first
 
 # Cubature requires vectors of Float64, so we serialize/deserialize
-function (s::Backend.Cubature)(f!, domain, result, args; params...)
+function (s::Backend.Cubature)(f!, domain, result)
     v = II.serialize_array(Float64, result)
-    # Could probably use unsafe_deserialize_array here, but we prefer safety.
-    fd!(point, out) = f!(II.deserialize_array(result, out), point..., args...; params...)
-    v .= first(hcubature(length(v), fd!, II.convert_domain(domain, s, args)...; s.opts...))
+    v .= first(hcubature(length(v), f!, domain...; s.opts...))
 	return result
 end
 

--- a/ext/IntegrationInterfaceHCubatureExt.jl
+++ b/ext/IntegrationInterfaceHCubatureExt.jl
@@ -4,15 +4,14 @@ using HCubature
 using IntegrationInterface
 import IntegrationInterface as II
 
-# supported domains (no need to deal with Domain.Functionals here)
-II.check_domain_solver(::Type{<:Domain.Box}, ::Backend.HCubature) = nothing
+II.convert_domain(s::Domain.Box, ::Backend.HCubature) = II.convert_domain_generic(s)
 
-II.convert_domain(s::Domain.Box, ::Backend.HCubature) = (s.mins, s.maxs)
+II.convert_integrand(i::II.Integral{Missing,<:Backend.HCubature}, domain, args; params...) =
+    II.convert_integrand_generic(i, domain, args; params...)
 
-(s::Backend.HCubature)(f, domain, ::Missing, args; params...) =
-	hcubature(point -> f(point..., args...; params...), II.convert_domain(domain, s, args)...; s.opts...) |> first
-
-(::Backend.HCubature)(f!, domain, result, args; params...) =
+II.convert_integrand(::II.Integral{<:Any,<:Backend.Cubature}, domain, args; params...) =
     throw(ArgumentError("HCubature does not support in-place integration. Use StaticArrays for array-valued integrands."))
+
+(s::Backend.HCubature)(f, domain, ::Missing) = hcubature(f, domain...; s.opts...) |> first
 
 end # module

--- a/ext/IntegrationInterfaceQuadGKExt.jl
+++ b/ext/IntegrationInterfaceQuadGKExt.jl
@@ -4,17 +4,15 @@ using QuadGK
 using IntegrationInterface
 import IntegrationInterface as II
 
-# supported domains (no need to deal with Domain.Functionals here)
-II.check_domain_solver(::Type{<:Union{Domain.Segment, Domain.SegmentGroup}}, ::Backend.QuadGK) = nothing
+II.convert_domain(s::Domain.Segment, ::Backend.QuadGK) =
+    II.convert_domain_generic(s)
 
-II.convert_domain(s::Domain.Segment, ::Backend.QuadGK) = (s.x1, s.x2)
-II.convert_domain(s::Domain.SegmentGroup, ::Backend.QuadGK) = (s.segments,)
+II.convert_integrand(i::II.Integral{Missing,<:Backend.QuadGK}, domain, args; params...) =
+    II.convert_integrand_generic(i, domain, args; params...)
 
 ## Call ##
 
-(s::Backend.QuadGK)(f, domain, ::Missing, args; params...) =
-	quadgk(x -> f(x..., args...; params...), II.convert_domain(domain, s, args)...; s.opts...) |> first
-(s::Backend.QuadGK)(f!, domain, result, args; params...) =
-	quadgk!((out, x) -> f!(out, x..., args...; params...), result, II.convert_domain(domain, s, args)...; s.opts...) |> first
+(s::Backend.QuadGK)(f, domain, ::Missing) = quadgk(f, domain...; s.opts...) |> first
+(s::Backend.QuadGK)(f!, domain, result) = quadgk!(f!, result, domain...; s.opts...) |> first
 
 end # module

--- a/src/IntegrationInterface.jl
+++ b/src/IntegrationInterface.jl
@@ -1,16 +1,20 @@
 module IntegrationInterface
 
-export integral, Backend, Domain
+export integral, Backend, Domain, Infinity
 
 # function stubs for extensions to extend
 function domainname end
 function convert_domain end
-function check_domain_solver end
+function convert_integrand end
+function ungroup end
+function sum_domains end
 
+include("types.jl")
 include("serialization.jl")
 include("domains.jl")
-include("solvers.jl")
-include("quadrature.jl")  # implementation of Backend.Quadrature, no extension required
+include("backends.jl")
 include("integral.jl")
+include("quadrature.jl")  # implementation of Backend.Quadrature, no extension required
+include("infinity.jl")
 
 end

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -1,16 +1,15 @@
-# We bundle AbstractBackends in a submodule to avoid name clashes with their
+# Integration solver backends are provided by external libraries and their extensions
+# Extensions must provide:
+#   - `convert_domain(domain, backend)`: a domain understood by backend, can fall back to
+#     `convert_domain_generic(domain)`
+#   - `convert_integrand(i::Integral, domain, args; params...)`: a function understood by
+#      the backend, can fall back to `convert_domain_generic(domain)`
+#   - `(::Backend)(integrand::Function, domain, result)`: call to actual implementation,
+#     once `integrand` and `domain` have been converted.
+#
+# We bundle all AbstractBackends in a Backend submodule to avoid name clashes with their
 # respective solver packages.
 
-abstract type AbstractBackend end
-
-# Support for Domain.Functional conversion for all backends. This dispatches to the
-# domain-specific convert_domain method, which is defined by each backend extension
-convert_domain(d::Domain.Functional, s::AbstractBackend, args) =
-    convert_domain(d(args...), s)
-convert_domain(d::AbstractDomain, s::AbstractBackend, _) =
-    convert_domain(d, s)
-convert_domain(::AbstractDomain, s::AbstractBackend) =
-    throw(ArgumentError("No conversion method for domain $(domainname(d)) defined for this backend. Forgot `using` the package for backend $(solvername(s))?"))
 
 ## Collection of backend solver types ##
 module Backend

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -1,56 +1,86 @@
-abstract type AbstractDomain end
-
 module Domain
 
-using IntegrationInterface: AbstractDomain
+using IntegrationInterface: AbstractDomain, NumberOrInfinity
 import IntegrationInterface as II
 
-struct Segment{T<:Number} <: AbstractDomain
-    x1::T
-    x2::T
+struct Segment{T1<:NumberOrInfinity,T2<:NumberOrInfinity} <: AbstractDomain
+    x1::T1
+    x2::T2
+    function Segment{T1,T2}(x1, x2) where {T1<:NumberOrInfinity,T2<:NumberOrInfinity}
+        error_if_degenerate(x1, x2)
+        return new(x1, x2)
+    end
 end
 
-struct SegmentGroup{T<:Number} <: AbstractDomain
-    segments::Vector{NTuple{2,T}}
+Segment(x1::T1, x2::T2) where {T1<:NumberOrInfinity,T2<:NumberOrInfinity} =
+    Segment{T1,T2}(x1, x2)
+
+struct Box{N,T1<:NTuple{N,NumberOrInfinity},T2<:NTuple{N,NumberOrInfinity}} <: AbstractDomain
+    mins::T1
+    maxs::T2
+    function Box{N,T1,T2}(mins, maxs) where {N,T1<:NTuple{N,NumberOrInfinity},T2<:NTuple{N,NumberOrInfinity}}
+        error_if_degenerate.(mins, maxs)
+        return new(mins, maxs)
+    end
 end
 
-struct Box{N,T<:Number} <: AbstractDomain
-    mins::NTuple{N,T}
-    maxs::NTuple{N,T}
-end
+Box(x1::T1, x2::T2) where {N,T1<:NTuple{N,NumberOrInfinity},T2<:NTuple{N,NumberOrInfinity}} =
+    Box{N,T1,T2}(x1, x2)
 
 struct Functional{D<:AbstractDomain,F} <: AbstractDomain
     type::Type{D}
     f::F
 end
 
-II.domainname(d::Segment) = "Segment($(d.x1), $(d.x2))"
-II.domainname(d::SegmentGroup) = "SegmentGroup($(d.segments))"
-II.domainname(d::Box) = "Box($(d.mins), $(d.maxs))"
+struct Sum{T<:NTuple{<:Any,AbstractDomain}} <: AbstractDomain
+    subdomains::T
+end
+
+error_if_degenerate(::Number, ::Number) = nothing
+error_if_degenerate(x1::NumberOrInfinity, x2::NumberOrInfinity) = II.point(x1) == II.point(x2) &&
+    throw(ArgumentError("Got a Domain.Segment corresponding to an unbounded ray with an ill-defined direction. "))
+
+II.domainname(d::Segment) = "Segment($(short_show(d.x1, d.x2)))"
+II.domainname(d::Sum) = string("Sum(", join(II.domainname.(d.subdomains), ", "), ")")
+II.domainname(d::Box) = "Box(($(short_show(d.mins...))), ($(short_show(d.maxs...)))))"
 II.domainname(d::Functional) = "Functional{$(nameof(d.type))}"
+
+short_show(d::II.Infinity) = "Infinity($(II.point(d)))"
+short_show(d::Number) = "$d"
+short_show(xs...) = join(short_show.(xs), ", ")
 
 ## API ##
 
 # constructors #
 
-Segment(x1::Number, x2::Number) = Segment(promote(x1, x2)...)
+Segment(s::NTuple{2,NumberOrInfinity}...) = Sum(Segment.(s))
 
-Segment((x1, x2)::NTuple{2,Number}) = Segment(x1, x2)
-
-Segment(s::NTuple{2,Number}...) = SegmentGroup(collect(s))
-
-function Segment(node1::Number, node2::Number, node3::Number, nodes::Number...)
-    nodes´ = promote(node1, node2, node3, nodes...)
-    return SegmentGroup(collect(zip(Base.front(nodes´), Base.tail(nodes´))))
+function Segment(node1::NumberOrInfinity, node2::NumberOrInfinity, node3::NumberOrInfinity, nodes::NumberOrInfinity...)
+    nodes´ = (node1, node2, node3, nodes...)
+    return Sum(Segment.(Base.front(nodes´), Base.tail(nodes´)))
 end
 
-(::Type{D})(f::F) where {D<:AbstractDomain,F<:Function} = Functional(D, f)
+(::Type{D})(f::Function) where {D<:AbstractDomain} = Functional(D, f)
+
+Sum(xs::AbstractDomain...) = Sum(xs)
+
+# Other
+
+Base.first(d::Segment) = d.x1
+Base.last(d::Segment) = d.x2
 
 # call #
 
-(f::Functional{D})(args...) where {D} = D(f.f(args...))
+(f::Functional{D})(args...; params...) where {D} = D(f.f(args...; params...)...)
 
-# conversions #
-ungroup(ss::SegmentGroup) = (Segment(s) for s in ss.segments)
+# ungroup domain sums
+
+II.ungroup(ss::Sum) = ss.subdomains
+
+# conversion
+
+to_segments(d::Box{N}) where {N} = ntuple(i -> Segment(d.mins[i], d.maxs[i]), Val(N))
+
+to_box(d::NTuple{N,Segment}) where {N} = Box(first.(d), last.(d))
 
 end

--- a/src/infinity.jl
+++ b/src/infinity.jl
@@ -1,0 +1,43 @@
+## Infinity ##
+# Deal with Infinity domain bounds.
+# See https://github.com/pablosanjose/IntegrationInterface.jl/issues/3 for details
+
+## API ##
+
+point(d::Infinity) = d.point
+point(x::Number) = x
+
+Base.:+(d::Infinity) = d
+Base.:-(d::Infinity) = Infinity(-point(d))
+
+## Tools for convert_integrand in the presence of Infinity ##
+
+# fallbacks
+change_of_variables(t, ::AbstractDomain) = t
+
+transform_domain(d::AbstractDomain) = d
+
+jacobian(t, d::AbstractDomain) = 1
+
+# Domain.Segment
+change_of_variables(t, d::Domain.Segment{<:Number,<:Infinity}) = d.x1 + delta(d) * t/(1-t)
+change_of_variables(t, d::Domain.Segment{<:Infinity, <:Number}) = d.x2 - delta(d) * t/(1-t)
+change_of_variables(t, d::Domain.Segment{<:Infinity, <:Infinity}) =
+    0.5*(point(d.x1)+point(d.x2)) + 0.75 * delta(d) * t/(1-t^2)
+
+jacobian(t, d::Domain.Segment{<:Number,<:Infinity}) = delta(d)/(1-t)^2
+jacobian(t, d::Domain.Segment{<:Infinity,<:Number}) = delta(d)/(1-t)^2
+jacobian(t, d::Domain.Segment{<:Infinity,<:Infinity}) = 0.75*delta(d)*(1+t^2)/(1-t^2)^2
+
+transform_domain(::Domain.Segment{<:Number,<:Infinity}) = Domain.Segment(0.0, 1.0)
+transform_domain(::Domain.Segment{<:Infinity,<:Number}) = Domain.Segment(0.0, 1.0)
+transform_domain(::Domain.Segment{<:Infinity,<:Infinity}) = Domain.Segment(-1.0, 1.0)
+
+delta(d::Domain.Segment) = point(d.x2) - point(d.x1)
+
+# Domain.Box - this is finicky, can easily produce allocations
+change_of_variables(t, d::Domain.Box) = change_of_variables.(t, Domain.to_segments(d))
+
+jacobian(t, d::Domain.Box) = prod(jacobian.(t, Domain.to_segments(d)))
+
+transform_domain(d::Domain.Box) = Domain.to_box(transform_domain.(Domain.to_segments(d)))

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -1,29 +1,27 @@
-struct Integral{R,S<:AbstractBackend,F,D}
-    integrand::F	# usually a function, but can be other kind of object
-    result::R		# will be Missing if not in-place
-    domain::D		# Tuple of AbstractDomains or a single AbstractDomain
-    solver::S		# object representing the integration solver backend(s)
-end
-
 ## API ##
-function integral(f::F, domain; result = missing, solver = default_solver(f, domain)) where {F}
-    domain´ = sanitize_domain(domain)
-    solver´ = sanitize_solver(solver, domain´)
-    check_domain_solver(domain´, solver´)
-	return Integral(f, result, domain´, solver´)
+function integral(f::F, domain::AbstractDomain; result = missing, solver::AbstractBackend = default_solver(domain)) where {F}
+	return Integral(f, result, domain, solver)
 end
 
 # currying version
 integral(domain; kw...) = f -> integral(f, domain; kw...)
 
-# fallback. Can be overridden for user-defined f types and domains
-default_solver(_...) = Backend.QuadGK()
+# Can be overridden for user-defined f types and domains
+default_solver(::Domain.Segment) = Backend.QuadGK()
+default_solver(::Domain.Sum{<:NTuple{<:Any,Domain.Segment}}) = Backend.QuadGK()
+default_solver(::Domain.Functional{<:Domain.Segment}) = Backend.QuadGK()
+default_solver(::Domain.Box) = Backend.HCubature()
+default_solver(::Domain.Sum{<:NTuple{<:Any,Domain.Box}}) = Backend.HCubature()
+default_solver(::Domain.Functional{<:Domain.Box}) = Backend.HCubature()
+default_solver(d) = throw(ArgumentError("No default solver exists for domain $(domainname(d))"))
 
 ismutating(i::Integral) = !ismissing(i.result)
 
 integrand(i::Integral) = i.integrand
 
 solver(i::Integral) = i.solver
+
+result(i::Integral) = i.result
 
 solvername(i::Integral) = solvername(solver(i))
 solvername(s::AbstractBackend) = nameof(typeof(s))
@@ -33,30 +31,71 @@ domain(i::Integral) = i.domain
 
 domainname(i::Integral) = domainname(domain(i))
 
-## sanitization ##
-
-sanitize_domain(domain::AbstractDomain) = domain
-sanitize_domain(domain) = throw(ArgumentError("Invalid domain specification $(domainname(domain))"))
-
-sanitize_solver(solver::AbstractBackend, ::AbstractDomain) = solver
-sanitize_solver(solver, domain) =
-    throw(ArgumentError("Invalid solver specification $(solvername(solver)) for the given domain $(domainname(domain)), or solver backend not loaded."))
-
-# error by default. Solvers must declare they understand the domain.
-
-# we translate to typeof(domain) to allow Functional to be checked automatically
-check_domain_solver(domain::AbstractDomain, solver::AbstractBackend) = check_domain_solver(typeof(domain), solver)
-check_domain_solver(domain::Domain.Functional, solver::AbstractBackend) = check_domain_solver(domain.type, solver)
-check_domain_solver(domain::Type{<:AbstractDomain}, solver::AbstractBackend) =
-    error("The integral solver $(solvername(solver)) does not support $(nameof(domain)) domains, or solver backend not loaded.")
-
 ## call syntax (scalar and in-place) ##
-(i::Integral{Missing})(args...; params...) = call!(i, args...; params...)
-(i::Integral)(args...; params...) = copy(call!(i, args...; params...))
+(i::Integral{Missing})(args...; params...) =
+    integrate(i, evaluate_domain(domain(i), args; params...), args; params...)
+(i::Integral)(args...; params...) =
+    copy(integrate(i, evaluate_domain(domain(i), args; params...), args; params...))
 
-call!(i::Integral, args...; params...) = i.solver(i.integrand, i.domain, i.result, args; params...)
+integrate(i::Integral, domain, args; params...) =
+    i.solver(convert_integrand(i, domain, args; params...), convert_domain(domain, i.solver), i.result)
 
-(s::AbstractBackend)(f, domain, result, args; params...) =
+# Any Domain Sum is handled by summing over the domains ##
+# non-mutating
+function integrate(i::Integral{Missing}, domain::Domain.Sum, args; params...)
+    result = sum(ungroup(domain)) do subdomain
+        subdomain´ = evaluate_domain(subdomain, args; params...)
+        integrate(i, convert_domain(subdomain´, i.solver), args; params...)
+    end
+    return result
+end
+
+# mutating
+function integrate(i::Integral, domain::Domain.Sum, args; params...)
+    resultsum = zero(result(i))
+    foreach(ungroup(domain)) do subdomain
+        subdomain´ = evaluate_domain(subdomain, args; params...)
+        resultsum .+= integrate(i, convert_domain(subdomain´, i.solver), args; params...)
+    end
+    return resultsum
+end
+
+evaluate_domain(d::Domain.Functional, args; params...) = d(args...; params...)
+evaluate_domain(d::AbstractDomain, args; params...) = d
+
+## Extension fallbacks and generics ##
+#   convert_domain, convert_integrand and solver(f, domain, result)
+
+# generic domain conversions (extensions must opt-in to these explicitly)
+convert_domain_generic(d::Domain.Segment{<:Number,<:Number}) =
+    (d.x1, d.x2)
+convert_domain_generic(d::Domain.Box{N,<:NTuple{N,Number},<:NTuple{N,Number}}) where {N} =
+    (d.mins, d.maxs)
+# Deal with Infinity - see infinity.jl
+convert_domain_generic(d::Domain.Segment) = convert_domain_generic(transform_domain(d))
+convert_domain_generic(d::Domain.Box) = convert_domain_generic(transform_domain(d))
+
+# generic integrand conversions (extensions must opt-in to these explicitly)
+function convert_integrand_generic(i::Integral{Missing}, domain, args; params...)
+    f = integrand(i)
+    f´(t) = jacobian(t, domain) * f(change_of_variables(t, domain)..., args...; params...)
+    return f´
+end
+
+function convert_integrand_generic(i::Integral, domain, args; params...)
+    f = integrand(i)
+    f´(out, t) = jacobian(t, domain) * f(out, change_of_variables(t, domain)..., args...; params...)
+    return f´
+end
+
+# failures
+convert_domain(d::AbstractDomain, s::AbstractBackend) =
+    throw(ArgumentError("No conversion method for domain $(domainname(d)) defined for this backend $(solvername(s)), or solver backend not loaded."))
+
+convert_integrand(i::Integral, domain, args; params...) =
+    throw(ArgumentError("No conversion method for the integrand defined for this backend $(solvername(i)), or solver backend not loaded."))
+
+(s::AbstractBackend)(f, domain, result) =
     error("The integral solver solver for $(nameof(typeof(s))) is not loaded.")
 
 ## Show ##

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -1,33 +1,32 @@
 ## Quadrature ##
-# this, unlike other solvers, does not require an extension
+# this backend, unlike other solvers, does not require an extension
+# we use the generic conversions to deal with Infinity segments, and then scale the domain
+# to [-1,1] to use the quadrature weights
 
-check_domain_solver(::Union{Domain.Segment, Domain.SegmentGroup}, ::Backend.Quadrature) = nothing
+convert_domain(s::Domain.Segment, ::Backend.Quadrature) =
+    convert_domain_generic(s)
 
-convert_domain(d::Domain.Segment, ::Backend.Quadrature) = (d.x1, d.x2)
+convert_integrand(i::Integral{Missing,<:Backend.Quadrature}, domain, args; params...) =
+    convert_integrand_generic(i, domain, args; params...)
 
-(s::Backend.Quadrature)(f, domain::Domain.SegmentGroup, result, args; params...) =
-    sum(ungroup(domain)) do segment
-        s(f, segment, missing, args; params...)
-    end
-
-function (s::Backend.Quadrature)(f, domain, ::Missing, args; params...)
-    xmin, xmax = convert_domain(domain, s)
+function (s::Backend.Quadrature)(f, domain, ::Missing)
+    xmin, xmax = domain
     Δx = 0.5 * (xmax - xmin)
     result = sum(zip(s.nodes, s.weights); init = zero(float(Δx))) do (t, w)
         x = (xmin + Δx * (t + 1))
-        return f(x..., args...; params...) * w * Δx
+        return f(x) * w * Δx
     end
     return result
 end
 
 function (s::Backend.Quadrature)(f!, domain, result, args; params...)
-    xmin, xmax = convert_domain(domain, s)
+    xmin, xmax = domain
     Δx = 0.5 * (xmax - xmin)
     fill!(result, 0)
     out = similar(result)
     foreach(zip(s.nodes, s.weights)) do (t, w)
         x = (xmin + Δx * (t + 1))
-        f!(out, x..., args...; params...)
+        f!(out, x)
         @. result += out * w * Δx
         return nothing
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,20 @@
+# All types not belonging in submodules are defined up-front to avoid include ordering problems
+
+abstract type AbstractDomain end
+
+abstract type AbstractBackend end
+
+# general callable object representing an integral over a domain using a solver backend
+struct Integral{R,S<:AbstractBackend,D<:AbstractDomain,F}
+    integrand::F	# usually a function, but can be other kind of object
+    result::R		# will be Missing if not in-place
+    domain::D		# Tuple of AbstractDomains or a single AbstractDomain
+    solver::S		# object representing the integration solver backend(s)
+end
+
+# represents an infinite ray passing through a point (direction fixed by another point´)
+struct Infinity{T}
+    point::T
+end
+
+const NumberOrInfinity = Union{Number,Infinity}


### PR DESCRIPTION
Closes #3 

This introduces `Infinity(point)` representing an unbounded ray passing through point. They can be used in place of numbers in `Domain.Segment` and `Domain.Box`.

We also cleaned up quite a bit.

(1) Extensions must now inplement fewer methods:
- `convert_domain(domain, backend)`: a domain understood by backend, can fall back to `convert_domain_generic(domain)`
- `convert_integrand(i::Integral, domain, args; params...)`: a function understood by backend, can fall back to `convert_domain_generic(domain)`
- `(::Backend)(integrand::Function, domain, result)`: call to actual implementation, once `integrand` and `domain` have been converted.

(2) Sums of domains are now wrapped in `Domain.Sum`, and integrals are computed with an explicit sum over each.

(3) We generalize `default_solver(domain)` to adapt to the domain in question
