### PR TITLE
Replace Domain.Line with Domain.Box1D

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The general interface reads
 ```julia
 julia> J = integral(f, domain; backend::AbstractBackend = default_backend(domain), result = nothing)
 ```
-This produces an `J::Integral` object. Possible domains are produced with `Domain.Line` or`Domain.Box`. Here `Backend` and `Domain` are exported submodules of `IntegrationInterface`. Functions of `args` can be passed to the constructor of a domain to make it depend on arguments passed to `J`.
+This produces an `J::Integral` object. Currently, only bounded and unbounded hypercube domains are possible. They are created with `Domain.Box`. For the interval of a 1D integral we have the alias `Domain.Box1D`. Functions of `args` can be passed to the constructor of a domain to make it depend on arguments and keywords passed to `J`.
 
 Mutating functions `f!(out, x..., args...; kw...)` that modify an `out::A` in-place can also be used. This is useful for heap-allocated integrands of type e.g. `A::AbstractArray`. In this pass an array of type `A` with the `result` keyword.
 
@@ -41,7 +41,7 @@ julia> J()
 
 As shown above, the integration is actually performed by backend packages that may be loaded as needed. Currently supported packages (weak dependencies) and corresponding backends in `IntegralBackends` are
 
-- QuadGK.jl: `Backend.QuadGK(; opts...)` (calls `quadgk` and `quadgk!`, default for `Domain.Line` domains)
+- QuadGK.jl: `Backend.QuadGK(; opts...)` (calls `quadgk` and `quadgk!`, default for `Domain.Box1D` domains)
 - HCubature.jl:  `Backend.HCubature(; opts...)` (calls `hcubature`, default for `Domain.Box` domains)
 - Cubature.jl: `Backend.Cubature(; opts...)` (calls `hcubature`)
 
@@ -51,17 +51,17 @@ julia> using FastGaussQuadrature, QuadGK
 
 julia> f(x) = cos(x);
 
-julia> J1 = integral(f, Domain.Line(3,5); backend = Backend.Quadrature(gausslegendre(10)))
+julia> J1 = integral(f, Domain.Box1D(3,5); backend = Backend.Quadrature(gausslegendre(10)))
 Integral
   Mutating   : false
-  Domain     : Line(3, 5)
+  Domain     : Box{1}(3, 5)
   Backend    : Quadrature
   Integrand  : f
 
-julia> J2 = integral(f, Domain.Line(3,5); backend = Backend.QuadGK())
+julia> J2 = integral(f, Domain.Box1D(3,5); backend = Backend.QuadGK())
 Integral
   Mutating   : false
-  Domain     : Line(3, 5)
+  Domain     : Box{1}(3, 5)
   Backend    : QuadGK
   Integrand  : f
 
@@ -82,14 +82,14 @@ This integral can be evaluated either as one adaptive `HCubature` or two nested 
 julia> f(x,y) = (x-y)^2 * cos(x+y)
 f (generic function with 2 methods)
 
-julia> J1 = f |> integral(Domain.Line(0,1)) |> integral(Domain.Line(2,3))
+julia> J1 = f |> integral(Domain.Box1D(0,1)) |> integral(Domain.Box1D(2,3))
 Integral
   Mutating   : false
-  Domain     : Line(2, 3)
+  Domain     : Box{1}(2, 3)
   Backend    : QuadGK
   Integrand  : Integral
     Mutating   : false
-    Domain     : Line(0, 1)
+    Domain     : Box{1}(0, 1)
     Backend    : QuadGK
     Integrand  : f
 
@@ -103,22 +103,22 @@ Integral
 julia> (J1(), J2())
 (-3.800374064781164, -3.800374064812097)
 ```
-Note the currying syntax used above for `J1`. It is equivalent to `J1 = integral(integral(f, Domain.Line(0,1)), Domain.Line(2,3))`.
+Note the currying syntax used above for `J1`. It is equivalent to `J1 = integral(integral(f, Domain.Box1D(0,1)), Domain.Box1D(2,3))`.
 
-We can also make inner domains depend on outer integration variables. For example,
+We can also make inner domains depend on outer integration variables. This provides one way to integrate over non-Box domains. For example,
 
 $$J = \int_{-1}^1 dy\int_{-\sqrt{1-y^2}}^{\sqrt{1-y^2}} dx (x-y)^2\cos(x+y) $$
 
 can be expressed as
 ```julia
-julia> J = f |> integral(Domain.Line(y -> (-sqrt(1-y^2), sqrt(1-y^2)))) |> integral(Domain.Line(-1,1))
+julia> J = f |> integral(Domain.Box1D(y -> (-sqrt(1-y^2), sqrt(1-y^2)))) |> integral(Domain.Box1D(-1,1))
 Integral
   Mutating   : false
-  Domain     : Line(-1, 1)
+  Domain     : Box{1}(-1, 1)
   Backend    : QuadGK
   Integrand  : Integral
     Mutating   : false
-    Domain     : Functional{Line}
+    Domain     : Functional{Box{1}}
     Backend    : QuadGK
     Integrand  : f
 
@@ -126,12 +126,14 @@ julia> J()
 1.324825188363749
 
 ```
-where we have passed a function to the `Domain.Line` instead of the line nodes.
+where we have passed a function to the `Domain.Box1D` instead of the box bounds.
 
-Some backends support using `Inf` to express unbounded domains. If that is not supported, we provide `Infinity(point::Number)` that can be used instead. It represents an unbounded ray passing though `point` (which may be Real or not). These `Infinite` bounds are dealt with using an appropriate change of variables that takes `point` into account. As an example, consider a 2D half-plane `D = Domain.Box((; σ = 1) -> ((0, -Infinity(σ)), (Infinity(σ), Infinity(σ))))`. Note that it is a `Domain.Functional` object that depends on `σ`. We can integrate a Gaussian over `D`, which gives `π` for `σ = 1`
+Some backends support using `Inf` to express unbounded domains. If that is not supported, we provide `Infinity(point::Number)` that can be used in box bounds instead. It represents an unbounded ray passing though `point` (which may be Real or not). These `Infinite` bounds are dealt with using an appropriate change of variables that takes `point` into account. As an example, consider a 2D half-plane `D = Domain.Box((; σ = 1) -> ((0, -Infinity(σ)), (Infinity(σ), Infinity(σ))))`. Note that it is a `Domain.Functional` object that depends on a keyword argument `σ`. We can integrate a Gaussian over `D`, which gives `π` for `σ = 1`
 
 ```julia
 julia> f(x, y; σ = 1) = exp(-0.5*(x^2+y^2)/σ^2);
+
+julia> D = Domain.Box((; σ = 1) -> ((0, -Infinity(σ)), (Infinity(σ), Infinity(σ))));
 
 julia> J = integral(f, D)
 Integral

--- a/ext/IntegrationInterfaceQuadGKExt.jl
+++ b/ext/IntegrationInterfaceQuadGKExt.jl
@@ -4,7 +4,7 @@ using QuadGK
 using IntegrationInterface
 import IntegrationInterface as II
 
-II.convert_domain(s::Domain.Line, ::Backend.QuadGK) =
+II.convert_domain(s::Domain.Box1D, ::Backend.QuadGK) =
     II.convert_domain_generic(s)
 
 II.convert_integrand(i::II.Integral{<:Any,<:Backend.QuadGK}, domain, args; kw...) =

--- a/src/changeofvariables.jl
+++ b/src/changeofvariables.jl
@@ -22,32 +22,32 @@ transform_domain(d::AbstractDomain) = d
 
 jacobian(t, d::AbstractDomain) = 1
 
-# Domain.Line
-change_of_variables(t, d::Domain.Line{<:Number,<:Infinity}) = d.x1 + delta(d) * t/(1-t)
-change_of_variables(t, d::Domain.Line{<:Infinity, <:Number}) = d.x2 - delta(d) * t/(1-t)
-change_of_variables(t, d::Domain.Line{<:Infinity, <:Infinity}) =
-    0.5*(point(d.x1)+point(d.x2)) + 0.75 * delta(d) * t/(1-t^2)
+# Domain.Box1D
+change_of_variables(t, d::Domain.Box1D{<:Number,<:Infinity}) = first(d) + delta(d) * t/(1-t)
+change_of_variables(t, d::Domain.Box1D{<:Infinity, <:Number}) = last(d) - delta(d) * t/(1-t)
+change_of_variables(t, d::Domain.Box1D{<:Infinity, <:Infinity}) =
+    0.5*(point(first(d))+point(last(d))) + 0.75 * delta(d) * t/(1-t^2)
 # complex case
-change_of_variables(t, d::Domain.Line{<:ComplexOrReal,<:ComplexOrReal}) = d.x1 + delta(d)*t
-change_of_variables(t, ::Domain.Line{<:Real,<:Real}) = t             # no transformation
+change_of_variables(t, d::Domain.Box1D{<:ComplexOrReal,<:ComplexOrReal}) = first(d) + delta(d)*t
+change_of_variables(t, ::Domain.Box1D{<:Real,<:Real}) = t             # no transformation
 
-jacobian(t, d::Domain.Line{<:Number,<:Infinity}) = delta(d)/(1-t)^2
-jacobian(t, d::Domain.Line{<:Infinity,<:Number}) = delta(d)/(1-t)^2
-jacobian(t, d::Domain.Line{<:Infinity,<:Infinity}) = 0.75*delta(d)*(1+t^2)/(1-t^2)^2
-jacobian(t, d::Domain.Line{<:ComplexOrReal,<:ComplexOrReal}) = delta(d)
-jacobian(t, ::Domain.Line{<:Real,<:Real}) = 1                        # no transformation
+jacobian(t, d::Domain.Box1D{<:Number,<:Infinity}) = delta(d)/(1-t)^2
+jacobian(t, d::Domain.Box1D{<:Infinity,<:Number}) = delta(d)/(1-t)^2
+jacobian(t, d::Domain.Box1D{<:Infinity,<:Infinity}) = 0.75*delta(d)*(1+t^2)/(1-t^2)^2
+jacobian(t, d::Domain.Box1D{<:ComplexOrReal,<:ComplexOrReal}) = delta(d)
+jacobian(t, ::Domain.Box1D{<:Real,<:Real}) = 1                        # no transformation
 
-transform_domain(::Domain.Line{<:Number,<:Infinity}) = Domain.Line(0.0, 1.0)
-transform_domain(::Domain.Line{<:Infinity,<:Number}) = Domain.Line(0.0, 1.0)
-transform_domain(::Domain.Line{<:Infinity,<:Infinity}) = Domain.Line(-1.0, 1.0)
-transform_domain(::Domain.Line{<:ComplexOrReal,<:ComplexOrReal}) = Domain.Line(0.0, 1.0)
-transform_domain(d::Domain.Line{<:Real,<:Real}) = d                  # no transformation
+transform_domain(::Domain.Box1D{<:Number,<:Infinity}) = Domain.Box1D(0.0, 1.0)
+transform_domain(::Domain.Box1D{<:Infinity,<:Number}) = Domain.Box1D(0.0, 1.0)
+transform_domain(::Domain.Box1D{<:Infinity,<:Infinity}) = Domain.Box1D(-1.0, 1.0)
+transform_domain(::Domain.Box1D{<:ComplexOrReal,<:ComplexOrReal}) = Domain.Box1D(0.0, 1.0)
+transform_domain(d::Domain.Box1D{<:Real,<:Real}) = d                  # no transformation
 
-delta(d::Domain.Line) = point(d.x2) - point(d.x1)
+delta(d::Domain.Box1D) = point(last(d)) - point(first(d))
 
 # Domain.Box - this is finicky, can easily produce allocations
-change_of_variables(t, d::Domain.Box) = change_of_variables.(t, Domain.to_lines(d))
+change_of_variables(t, d::Domain.Box) = change_of_variables.(t, Domain.to_1D_boxes(d))
 
-jacobian(t, d::Domain.Box) = prod(jacobian.(t, Domain.to_lines(d)))
+jacobian(t, d::Domain.Box) = prod(jacobian.(t, Domain.to_1D_boxes(d)))
 
-transform_domain(d::Domain.Box) = Domain.to_box(transform_domain.(Domain.to_lines(d)))
+transform_domain(d::Domain.Box) = Domain.to_box(transform_domain.(Domain.to_1D_boxes(d)))

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -3,31 +3,20 @@ module Domain
 using IntegrationInterface: AbstractDomain, NumberOrInfinity
 import IntegrationInterface as II
 
-struct Line{T1<:NumberOrInfinity,T2<:NumberOrInfinity} <: AbstractDomain
-    x1::T1
-    x2::T2
-    function Line{T1,T2}(x1, x2) where {T1<:NumberOrInfinity,T2<:NumberOrInfinity}
-        error_if_degenerate(x1, x2)
-        x1´, x2´ = sanitize_infs(x1, x2)
-        return new(x1´, x2´)
-    end
-end
-
-Line(x1::T1, x2::T2) where {T1<:NumberOrInfinity,T2<:NumberOrInfinity} =
-    Line{T1,T2}(x1, x2)
-
-struct Box{N,T1<:NTuple{N,NumberOrInfinity},T2<:NTuple{N,NumberOrInfinity}} <: AbstractDomain
-    mins::T1
-    maxs::T2
-    function Box{N,T1,T2}(mins, maxs) where {N,T1<:NTuple{N,NumberOrInfinity},T2<:NTuple{N,NumberOrInfinity}}
+struct Box{N,P1<:NTuple{N,NumberOrInfinity},P2<:NTuple{N,NumberOrInfinity}} <: AbstractDomain
+    mins::P1
+    maxs::P2
+    function Box{N,P1,P2}(mins, maxs) where {N,P1<:NTuple{N,NumberOrInfinity},P2<:NTuple{N,NumberOrInfinity}}
         error_if_degenerate.(mins, maxs)
         mins´, maxs´ = sanitize_infs(mins, maxs)
         return new(mins´, maxs´)
     end
 end
 
-Box(x1::T1, x2::T2) where {N,T1<:NTuple{N,NumberOrInfinity},T2<:NTuple{N,NumberOrInfinity}} =
-    Box{N,T1,T2}(x1, x2)
+const Box1D{T1,T2} = Box{1,Tuple{T1},Tuple{T2}}
+
+Box(x1::P1, x2::P2) where {N,P1<:NTuple{N,NumberOrInfinity},P2<:NTuple{N,NumberOrInfinity}} =
+    Box{N,P1,P2}(x1, x2)
 
 struct Functional{D<:AbstractDomain,F} <: AbstractDomain
     type::Type{D}
@@ -41,7 +30,7 @@ end
 ## Sanitization ##
 error_if_degenerate(::Number, ::Number) = nothing
 error_if_degenerate(x1::NumberOrInfinity, x2::NumberOrInfinity) = II.point(x1) == II.point(x2) &&
-    throw(ArgumentError("Got a Domain.Line corresponding to an unbounded ray with an ill-defined direction. "))
+    throw(ArgumentError("Got a domain corresponding to an unbounded ray with an ill-defined direction. "))
 
 # Should not mix Infinity with Inf. Also, Complex infs are not allowed
 function sanitize_infs(x1::Tuple, x2::Tuple)
@@ -60,9 +49,9 @@ sanitize_complex_inf(x::Complex) =
 sanitize_complex_inf(x) = x
 
 ## Show ##
-II.domainname(d::Line) = "Line($(short_show(d.x1, d.x2)))"
 II.domainname(d::Sum) = string("Sum(", join(II.domainname.(d.subdomains), ", "), ")")
-II.domainname(d::Box) = "Box(($(short_show(d.mins...))), ($(short_show(d.maxs...)))))"
+II.domainname(d::Box{N}) where {N} = "Box{$N}(($(short_show(d.mins...))), ($(short_show(d.maxs...)))))"
+II.domainname(d::Box{1}) = "Box{1}($(short_show(only(d.mins))), $(short_show(only(d.maxs))))"
 II.domainname(d::Functional) = "Functional{$(nameof(d.type))}"
 
 short_show(d::II.Infinity) = "Infinity($(II.point(d)))"
@@ -71,25 +60,32 @@ short_show(xs...) = join(short_show.(xs), ", ")
 
 ## API ##
 
-Line(s::NTuple{2,NumberOrInfinity}...) = Sum(Line.(s))
+# 1D box
+Box1D(a::NumberOrInfinity, b::NumberOrInfinity) = Box((a,), (b,))
 
-function Line(node1::NumberOrInfinity, node2::NumberOrInfinity, node3::NumberOrInfinity, nodes::NumberOrInfinity...)
+# Sum of 1D boxes
+Box1D(s::NTuple{2,NumberOrInfinity}...) = Sum(Box.(s))
+
+# Sum of consecutive 1D boxes
+function Box1D(node1::NumberOrInfinity, node2::NumberOrInfinity, node3::NumberOrInfinity, nodes::NumberOrInfinity...)
     nodes´ = (node1, node2, node3, nodes...)
-    return Sum(Line.(Base.front(nodes´), Base.tail(nodes´)))
+    return Sum(Box1D.(Base.front(nodes´), Base.tail(nodes´)))
 end
 
-function Line(nodes::AbstractVector)
-    return Sum(Line(nodes[i], nodes[i+1]) for i in eachindex(nodes)[1:end-1])
+# As above, but with an AbstractVector
+function Box1D(nodes::AbstractVector)
+    return Sum(Box1D(nodes[i], nodes[i+1]) for i in eachindex(nodes)[1:end-1])
 end
 
+# Functional domain
 (::Type{D})(f::Function) where {D<:AbstractDomain} = Functional(D, f)
 
 Sum(xs::AbstractDomain...) = Sum(xs)
 
 # accessors #
 
-Base.first(d::Line) = d.x1
-Base.last(d::Line) = d.x2
+Base.first(d::Box1D) = only(d.mins)
+Base.last(d::Box1D) = only(d.maxs)
 
 Base.first(d::Box) = d.mins
 Base.last(d::Box) = d.maxs
@@ -104,8 +100,8 @@ II.ungroup(ss::Sum) = ss.subdomains
 
 # conversion
 
-to_lines(d::Box{N}) where {N} = ntuple(i -> Line(d.mins[i], d.maxs[i]), Val(N))
+to_1D_boxes(d::Box{N}) where {N} = ntuple(i -> Box1D(d.mins[i], d.maxs[i]), Val(N))
 
-to_box(d::NTuple{N,Line}) where {N} = Box(first.(d), last.(d))
+to_box(d::NTuple{N,Box1D}) where {N} = Box(first.(d), last.(d))
 
 end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -7,9 +7,9 @@ end
 integral(domain; kw...) = f -> integral(f, domain; kw...)
 
 # Can be overridden for user-defined f types and domains
-default_backend(::Domain.Line) = Backend.QuadGK()
-default_backend(::Domain.Sum{<:NTuple{<:Any,Domain.Line}}) = Backend.QuadGK()
-default_backend(::Domain.Functional{<:Domain.Line}) = Backend.QuadGK()
+default_backend(::Domain.Box1D) = Backend.QuadGK()
+default_backend(::Domain.Sum{<:NTuple{<:Any,Domain.Box1D}}) = Backend.QuadGK()
+default_backend(::Domain.Functional{<:Domain.Box1D}) = Backend.QuadGK()
 default_backend(::Domain.Box) = Backend.HCubature()
 default_backend(::Domain.Sum{<:NTuple{<:Any,Domain.Box}}) = Backend.HCubature()
 default_backend(::Domain.Functional{<:Domain.Box}) = Backend.HCubature()
@@ -65,13 +65,13 @@ evaluate_domain(d::AbstractDomain, args; kw...) = d
 #   convert_domain, convert_integrand and backend(f, domain, result)
 
 # generic domain conversions (extensions must opt-in to these explicitly)
-convert_domain_generic(d::Domain.Line{<:Real,<:Real}) =
-    (d.x1, d.x2)
+convert_domain_generic(d::Domain.Box1D{<:Real,<:Real}) =
+    (first(d), last(d))
 convert_domain_generic(d::Domain.Box{N,<:NTuple{N,Real},<:NTuple{N,Real}}) where {N} =
-    (d.mins, d.maxs)
+    (first(d), last(d))
 
 # Deal with Infinity and complex-to-real conversions - see changeofvariables.jl
-convert_domain_generic(d::Domain.Line) = convert_domain_generic(transform_domain(d))
+convert_domain_generic(d::Domain.Box1D) = convert_domain_generic(transform_domain(d))
 convert_domain_generic(d::Domain.Box) = convert_domain_generic(transform_domain(d))
 
 # generic integrand conversions (extensions must opt-in to these explicitly)

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -1,9 +1,9 @@
 ## Quadrature ##
 # this backend, unlike other backends, does not require an extension
-# we use the generic conversions to deal with Infinity lines, and then scale the domain
+# we use the generic conversions to deal with Infinity boxes, and then scale the domain
 # to [-1,1] to use the quadrature weights
 
-convert_domain(s::Domain.Line, ::Backend.Quadrature) =
+convert_domain(s::Domain.Box1D, ::Backend.Quadrature) =
     convert_domain_generic(s)
 
 convert_integrand(i::Integral{<:Any,<:Backend.Quadrature}, domain, args; kw...) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,39 +10,39 @@ const II = IntegrationInterface
     # basics
     f(x) = cos(x)
     f(x, p; σ = 2, λ = 0) = (σ + cos(p*x))*exp(-abs(x)*λ)
-    J = integral(f, Domain.Line(0,π/2))
+    J = integral(f, Domain.Box1D(0,π/2))
     @test II.backend(J) isa Backend.QuadGK     #default
     @test J() ≈ 1
     @test J(2; σ = 1) ≈ π/2
     @test J(1; σ = 0, λ = 1) ≈ 0.5*(1+exp(-π/2))
 
     # Infs
-    J = integral(f, Domain.Line(0, Inf))
+    J = integral(f, Domain.Box1D(0, Inf))
     @test J(1; σ = 0, λ = 1) ≈ 0.5
-    J = integral(f, Domain.Line(-Inf, Inf))
+    J = integral(f, Domain.Box1D(-Inf, Inf))
     @test J(1; σ = 0, λ = 1) ≈ 1.0
-    J = integral(f, Domain.Line(0,Infinity(1)))
+    J = integral(f, Domain.Box1D(0,Infinity(1)))
     @test J(1; σ = 0, λ = 1) ≈ 0.5
-    J = integral(f, Domain.Line(-Infinity(1), Infinity(1)))
+    J = integral(f, Domain.Box1D(-Infinity(1), Infinity(1)))
     @test J(1; σ = 0, λ = 1) ≈ 1.0
      # mixing Inf with Infinity is ambiguous
-    @test_throws ArgumentError integral(f, Domain.Line(-Infinity(1), Inf))
+    @test_throws ArgumentError integral(f, Domain.Box1D(-Infinity(1), Inf))
 
     # bounds as args
     g(x, _...) = exp(-0.5*x^2)
-    J = integral(g, Domain.Line((a,b) -> (a,b)))
+    J = integral(g, Domain.Box1D((a,b) -> (a,b)))
     @test J(0, Inf) ≈ -J(0, -Inf) ≈ - J(Inf, 0) ≈  J(-Inf, 0) ≈ √(π/2)
     @test J(-Inf, Inf) ≈ -J(Inf, -Inf) ≈ J(-Infinity(1), Infinity(1)) ≈ √(2π)
 
     # complex version
     h(x, _...) = exp(x)
-    J = integral(h, Domain.Line((a,b) -> (a,b)))
+    J = integral(h, Domain.Box1D((a,b) -> (a,b)))
     @test J(1+2im, 3.0+3im) ≈  h(3.0+3im, 0, 0) - h(1+2im, 0, 0)
 
     # in-place version
     result = zeros(Float64, 10)
     g!(out, x, _...) = (out .= exp.(x .* eachindex(out)))
-    J = integral(g!, Domain.Line((a,b) -> (a,b)); result)
+    J = integral(g!, Domain.Box1D((a,b) -> (a,b)); result)
     @test J(0, 1) === result ≈ (exp.(eachindex(result)) .- 1) ./ eachindex(result)
 end
 
@@ -112,23 +112,23 @@ end
 @testset "Nested" begin
     # 2D
     f(x, y) = cos(x^2+y)*exp(-0.5*(x^2+2y^2))
-    J1 = f |> integral(Domain.Line(-Inf, Inf)) |> integral(Domain.Line(-Infinity(1),Infinity(1)))
+    J1 = f |> integral(Domain.Box1D(-Inf, Inf)) |> integral(Domain.Box1D(-Infinity(1),Infinity(1)))
     J2 = f |> integral(Domain.Box((-Infinity(1), -Infinity(1)),(Infinity(1), Infinity(1))))
     @test J1() ≈ J2()
-    J1 = f |> integral(Domain.Line(0, 20)) |> integral(Domain.Line(-Infinity(1),Infinity(5)))
+    J1 = f |> integral(Domain.Box1D(0, 20)) |> integral(Domain.Box1D(-Infinity(1),Infinity(5)))
     J2 = f |> integral(Domain.Box((0, -Infinity(1)),(20, Infinity(1))))
     @test J1() ≈ J2()
     # 3D
     f(x, y, z) = cos(x+2y+3z)
-    J1 = f |> integral(Domain.Line(-1, 1)) |> integral(Domain.Box((0, 0),(1, 2+im)))
-    J2 = f |> integral(Domain.Box((-1, 0),(1, 1))) |> integral(Domain.Line(0, 2+im))
-    J3 = f |> integral(Domain.Line(-1, 1)) |> integral(Domain.Line(0, 1)) |> integral(Domain.Line(0, 2+im))
+    J1 = f |> integral(Domain.Box1D(-1, 1)) |> integral(Domain.Box((0, 0),(1, 2+im)))
+    J2 = f |> integral(Domain.Box((-1, 0),(1, 1))) |> integral(Domain.Box1D(0, 2+im))
+    J3 = f |> integral(Domain.Box1D(-1, 1)) |> integral(Domain.Box1D(0, 1)) |> integral(Domain.Box1D(0, 2+im))
     J4 = f |> integral(Domain.Box((-1, 0, 0),(1, 1, 2+im)))
     @test J1() ≈ J2() ≈ J3() ≈ J4()
     f(x, y, z) = exp(-abs(x+2y+3z))
-    J1 = f |> integral(Domain.Line(-1, 1)) |> integral(Domain.Box((0, -Infinity(2+3im)),(1, 2+im)))
-    J2 = f |> integral(Domain.Box((-1, 0),(1, 1))) |> integral(Domain.Line(-Infinity(2+3im), 2+im))
-    J3 = f |> integral(Domain.Line(-1, 1)) |> integral(Domain.Line(0, 1)) |> integral(Domain.Line(-Infinity(2+3im), 2+im))
+    J1 = f |> integral(Domain.Box1D(-1, 1)) |> integral(Domain.Box((0, -Infinity(2+3im)),(1, 2+im)))
+    J2 = f |> integral(Domain.Box((-1, 0),(1, 1))) |> integral(Domain.Box1D(-Infinity(2+3im), 2+im))
+    J3 = f |> integral(Domain.Box1D(-1, 1)) |> integral(Domain.Box1D(0, 1)) |> integral(Domain.Box1D(-Infinity(2+3im), 2+im))
     J4 = f |> integral(Domain.Box((-1, 0, -Infinity(2+3im)),(1, 1, 2+im)))
     @test J1() ≈ J2() ≈ J3() ≈ J4()
 end
@@ -136,10 +136,10 @@ end
 
 @testset "Domain sums" begin
     f(x) = 1/(x^2+1)
-    J = integral(f, Domain.Line(0, 1, 1+2im, -1+2im, -1, 0))
+    J = integral(f, Domain.Box1D(0, 1, 1+2im, -1+2im, -1, 0))
     @test J() ≈ π
     f(x) = 1/(x-im)
     @test J() ≈ 2π*im
-    J = integral(f, Domain.Line([0, 1, 1+2im, -1+2im, -1, 0]); backend = Backend.QuadGK())
+    J = integral(f, Domain.Box1D([0, 1, 1+2im, -1+2im, -1, 0]); backend = Backend.QuadGK())
     @test J() ≈ 2π*im
 end


### PR DESCRIPTION
Close #13 

The approach here is to have one single `Domain.Box` object that covers the case of a 1D segment. For convenience we define an alias `Domain.Box1D{T1,T2} = Domain.Box{1,Tuple{T1},Tuple{T2}` for this case.

With this we no longer have `Domain.Line` anywhere. For 1D integration domains `(a,b)` we need to write `Domain.Box1D(a,b)`. For a juxtaposition of contigous domains, `Domain.Box1D(a,b,c, d...)` (useful for polygonal paths on the complex plane). 