### PR TITLE
Support nested and mutating integrals with functional domains

### DIFF
--- a/src/integral.jl
+++ b/src/integral.jl
@@ -1,7 +1,7 @@
 ## API ##
 Integral(f::F, domain; result = nothing, backend = Backend.default(domain)) where {F} =
-	Integral(f, result, maybe_functional(domain), backend)
-Integral(domain; kw...) = f -> Integral(f, maybe_functional(domain); kw...)  # currying version
+	Integral(maybe_mutating(f, result), result, maybe_functional(domain), backend)
+Integral(domain; kw...) = f -> Integral(f, domain; kw...)  # currying version
 
 # autoevaluated integral (need two methods due to ambiguities)
 integral(f, domain, args...; result = nothing, backend = Backend.default(domain), kw...) =
@@ -9,6 +9,12 @@ integral(f, domain, args...; result = nothing, backend = Backend.default(domain)
 
 maybe_functional(domain::AbstractDomain) = domain
 maybe_functional(domain) = Domain.Functional(domain)  # assumed callable
+
+# if the integrand J is an Integral, mutation is handled externally to J
+# (we should not pass `out` to J and its domains)
+maybe_mutating(J::Integral, ::Nothing) = J
+maybe_mutating(J::Integral, _) = Mutating(J)
+maybe_mutating(f, _) = f
 
 ismutating(i::Integral) = !isnothing(i.result)
 
@@ -40,3 +46,5 @@ $i  Backend    : $(backendname(J))
 $i  Integrand  : ")
   print(ioindent, integrand(J))
 end
+
+Base.show(io::IO, J::Mutating) = (print(io, "[Mutating] "); show(io, J.f))

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,11 +7,18 @@ abstract type AbstractBackend end
 
 # general callable object representing an integral over a domain using a backend
 struct Integral{R,S<:AbstractBackend,D<:AbstractDomain,F}
-    integrand::F	# usually a function, but can be other kind of object
+    integrand::F	# usually a function, but can be other kind of object, such as an Integral
     result::R		# will be `nothing` if not in-place
     domain::D		# Tuple of AbstractDomains or a single AbstractDomain
     backend::S		# object representing the integration  backend(s)
 end
+
+# used to wrap and integrand::Integral in a mutating case, so that it can be called without `out` argument
+struct Mutating{F}
+    f::F
+end
+
+(m::Mutating)(out, args...; kw...) = out .= m.f(args...; kw...)
 
 # represents an infinite ray passing through a point (direction fixed by another point´)
 struct Infinity{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,6 +262,17 @@ end
     @test value ≈ J2()
     @test error < 1e-8
 
+    # nested with mutation
+    using HCubature.StaticArrays
+    f!(out, x, y, a; σ = 0.5) = out .= cos(x^2+y*a)*exp(-σ*(x^2+2y^2)) .* eachindex(out)
+    f(x, y, a; σ = 0.5) = cos(x^2+y*a)*exp(-σ*(x^2+2y^2)) * SVector{10,Float64}(1:10)
+    result = zeros(Float64, 10)
+    domainouter(a; σ = 0.5) = Domain.Box(σ, a)
+    domaininner(x, a; σ = 0.5) = Domain.Box(σ, a)
+    J1 = f! |> Integral(domaininner; result) |> Integral(domainouter; result = copy(result))
+    J2 = f |> Integral(domaininner) |> Integral(domainouter)
+    @test J1(1) ≈ J2(1)
+
     # 3D
     f(x, y, z) = cos(x+2y+3z)
     J1 = f |> Integral(Domain.Box(-1, 1)) |> Integral(Domain.Box((0, 0),(1, 2+im)))


### PR DESCRIPTION
If we attempted to do a nested integral with mutation, and domains are functional, the latter would receive the mutating argument `out`, preceding the rest of the arguments. Since `J::Integral` was designed to be evaluated as `J(args...; kw...)` and not as `J(out, args...; kw...)`, this would fail.
With this PR, when the integrand is an `Integral`, it will be wrapped in a `Mutating` wrapper, that will drop `out` when called, forwarding the remaining `args` and `kw` to `J`, and only then copying the results to `out`.