### PR TITLE
Unitful support in HAdaptiveIntegration backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ IntegrationInterfaceQuadGKExt = "QuadGK"
 IntegrationInterfaceSparseArraysExt = "SparseArrays"
 
 [compat]
-HAdaptiveIntegration = "1.0.1"
+HAdaptiveIntegration = "1.1"
 Cubature = "1.5.1"
 HCubature = "1.8.0"
 QuadGK = "2.11.2"

--- a/ext/IntegrationInterfaceHAdaptiveIntegrationExt.jl
+++ b/ext/IntegrationInterfaceHAdaptiveIntegrationExt.jl
@@ -20,15 +20,15 @@ function II.convert_domain(d::Domain.Simplex, ::Backend.HAdaptiveIntegration)
 end
 
 II.convert_integrand(i::II.Integral{Nothing}, ::Backend.HAdaptiveIntegration, domain::II.Domain.Box, args; kw...) =
-    II.convert_integrand_generic(i, domain, args; post = ensure_real_or_complex, kw...)
+    II.convert_integrand_generic(i, domain, args; kw...)
 
 II.convert_integrand(i::II.Integral{Nothing}, ::Backend.HAdaptiveIntegration, domain::II.Domain.FiniteRealSimplex, args; kw...) =
-    II.convert_integrand_generic(i, domain, args; post = ensure_real_or_complex, kw...)
+    II.convert_integrand_generic(i, domain, args; kw...)
 
 function II.convert_integrand(i::II.Integral{Nothing}, ::Backend.HAdaptiveIntegration, domain::II.Domain.Simplex{N}, args; kw...) where {N}
     _, basis, _, _ = Domain.basisdata(domain)
     volume = det(hcat(SVector.(basis)...))
-    return II.convert_integrand_generic(i, domain, args; post = x -> ensure_real_or_complex(x) * volume, kw...)
+    return II.convert_integrand_generic(i, domain, args; post = x -> x * volume, kw...)
 end
 
 II.convert_integrand(::II.Integral{<:Any}, ::Backend.HAdaptiveIntegration, domain, args; kw...) =
@@ -40,9 +40,5 @@ II.convert_integrand(::II.Integral{<:Any}, ::Backend.HAdaptiveIntegration, domai
 error_if_inf_HAdaptiveIntegration(xs) = foreach(error_if_inf_HAdaptiveIntegration, xs)
 error_if_inf_HAdaptiveIntegration(x::Number) = isinf(x) &&
     throw(ArgumentError("The HAdaptiveIntegration backend cannot deal with domains with `Inf`s. Use `Infinity` instead."))
-
-ensure_real_or_complex(x::Union{Real,Complex}) = x
-ensure_real_or_complex(x::AbstractArray{<:Union{Real,Complex}}) = x
-ensure_real_or_complex(_) = throw(ArgumentError("HAdaptiveIntegration only understand functions with Real or Complex values or eltypes, but not other Numbers like Unitful."))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,11 +34,12 @@ end
     @test J1() ≈ π/2 * u"A"^2
     @test J2() ≈ π/2 * u"A"^2 atol = 1e-4*u"A"^2
     # 2D
+    SupportedWithUnits = Union{Backend.Quadrature, Backend.HAdaptiveIntegration}
     for backend in (Backend.Quadrature(gausslegendre(50)), Backend.HCubature(), Backend.Cubature(), Backend.HAdaptiveIntegration())
         J = Integral((x,y)->cos(ustrip(x+y)), Domain.Box((0u"A", 0u"A"), (π/2 * u"A", π * u"A")); backend)
-        backend isa Backend.Quadrature ? (@test (J() ≈ -2u"A"^2)) : (@test_throws ArgumentError J())
+        backend isa SupportedWithUnits ? (@test (J() ≈ -2u"A"^2)) : (@test_throws ArgumentError J())
         J = Integral((x,y)->x*y*u"A", Domain.Box((0,0),(1,1)); backend)
-        backend isa Backend.Quadrature ? (@test (J() ≈ 0.25u"A")) : (@test_throws ArgumentError J())
+        backend isa SupportedWithUnits ? (@test (J() ≈ 0.25u"A")) : (@test_throws ArgumentError J())
     end
 end
 


### PR DESCRIPTION
Following the HAdaptiveIntegration v1.1 update, this backend now supports Unitful, so we stop checking for dimensionless integrands and domains in this case.