### PR TITLE
Release v0.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntegrationInterface"
 uuid = "03ca86a4-b7cd-4b10-a38f-d7a84f40de1e"
 authors = ["Pablo San-Jose <lekand@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 


### PR DESCRIPTION
Release v0.1.1

What's new:

- Deals with the edge case of `Domain.interval(v::Vector)` with `length(v) = 2` (#44)
- Deals with the not-so-edge case of a mutating integral with an`J::Integral` integrand, which of course doesn't understand the mutating `J(out, args...)` syntax out of the box (#45)
- Allows passing Unitful quantities to the HAdaptiveIntegration.jl backend, which since v1.1 supports Unitful (#47).