### PR TITLE
Allow 1D integrals with HCubature and Cubature backends

### DIFF
--- a/ext/IntegrationInterfaceCubatureExt.jl
+++ b/ext/IntegrationInterfaceCubatureExt.jl
@@ -23,15 +23,19 @@ function II.convert_integrand(i::II.Integral{<:Any}, ::Backend.Cubature, d, args
     return fd!
 end
 
-(s::Backend.Cubature)(f, domain, ::Nothing, witherror) = hcubature(f, domain...; s.opts...)
+(s::Backend.Cubature)(f, domain, ::Nothing, witherror) = hquadrature_or_hcubature(f, domain...; s.opts...)
 
 # Cubature requires vectors of Float64, so we serialize/deserialize
 function (s::Backend.Cubature)(f!, domain, result, witherror)
     v = II.serialize_array(Float64, result)
-    value, error = hcubature(length(v), f!, domain...; s.opts...)
+    value, error = hquadrature_or_hcubature(length(v), f!, domain...; s.opts...)
     v .= value
 	return result, error
 end
+
+hquadrature_or_hcubature(f, min::Number, max::Number; kw...) = hquadrature(f, min, max; kw...)
+hquadrature_or_hcubature(n, f!, min::Number, max::Number; kw...) = hquadrature(n, f!, min, max; kw...)
+hquadrature_or_hcubature(args...; kw...) = hcubature(args...; kw...)
 
 (s::Backend.Cubature)(f, domain, result) = first(s(f, domain, result, true))
 

--- a/ext/IntegrationInterfaceHCubatureExt.jl
+++ b/ext/IntegrationInterfaceHCubatureExt.jl
@@ -13,8 +13,11 @@ II.convert_integrand(i::II.Integral{Nothing}, ::Backend.HCubature, domain, args;
 II.convert_integrand(::II.Integral{<:Any}, ::Backend.HCubature, domain, args; kw...) =
     throw(ArgumentError("HCubature does not support in-place integration. Use StaticArrays for array-valued integrands."))
 
-(s::Backend.HCubature)(f, domain, ::Nothing, witherror) = hcubature(f, domain...; s.opts...)
+(s::Backend.HCubature)(f, domain, ::Nothing, witherror) = hquadrature_or_hcubature(f, domain...; s.opts...)
 (s::Backend.HCubature)(f, domain, result) = s(f, domain, result, true) |> first
+
+hquadrature_or_hcubature(f, min::Number, max::Number; kw...) = hquadrature(f, min, max; kw...)
+hquadrature_or_hcubature(args...; kw...) = hcubature(args...; kw...)
 
 error_if_Inf(s::Domain.Box) = any(error_if_Inf, first(s)) || any(error_if_Inf, last(s)) || s
 error_if_Inf(x::Number) = isinf(x) &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,6 +150,11 @@ end
     @test J() ≈ -2
     @test J(2; λ = 2, σ = 1) ≈ 1.4803924093
 
+    # 1D version
+    J = Integral(exp, Domain.Box(0,1); backend = Backend.HCubature())
+    @test II.backend(J) isa Backend.HCubature
+    @test J() ≈ exp(1) - 1
+
     # witherror
     value, error = J |> witherror(2; λ = 2, σ = 1)
     @test value ≈ 1.4803924093
@@ -183,6 +188,11 @@ end
     @test II.backend(J) isa Backend.Cubature   # default
     @test J() ≈ -2
     @test J(2; λ = 2, σ = 1) ≈ 1.4803924093
+
+    # 1D version
+    J = Integral(exp, Domain.Box(0,1); backend = Backend.Cubature())
+    @test II.backend(J) isa Backend.Cubature
+    @test J() ≈ exp(1) - 1
 
     # witherror
     value, error = witherror(J, 2; λ = 2, σ = 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,17 +143,17 @@ end
 end
 
 @testset "HCubature" begin
+    # 1D version
+    J = Integral(exp, Domain.Box(0,1); backend = Backend.HCubature())
+    @test II.backend(J) isa Backend.HCubature
+    @test J() ≈ exp(1) - 1
+
     f(x, y) = cos(x+y)
     f(x, y, p; σ = 2, λ = 0) = (cos(x+p*y)+λ)*exp(-(x^2+(p*y)^2)/(2*σ^2))
     J = Integral(f, Domain.Box((0,0),(π/2,π)))
     @test II.backend(J) isa Backend.HCubature   # default
     @test J() ≈ -2
     @test J(2; λ = 2, σ = 1) ≈ 1.4803924093
-
-    # 1D version
-    J = Integral(exp, Domain.Box(0,1); backend = Backend.HCubature())
-    @test II.backend(J) isa Backend.HCubature
-    @test J() ≈ exp(1) - 1
 
     # witherror
     value, error = J |> witherror(2; λ = 2, σ = 1)
@@ -182,17 +182,17 @@ end
 end
 
 @testset "Cubature" begin
+    # 1D version
+    J = Integral(exp, Domain.Box(0,1); backend = Backend.Cubature())
+    @test II.backend(J) isa Backend.Cubature
+    @test J() ≈ exp(1) - 1
+
     f(x, y) = cos(x+y)
     f(x, y, p; σ = 2, λ = 0) = (cos(x+p*y)+λ)*exp(-(x^2+(p*y)^2)/(2*σ^2))
     J = Integral(f, Domain.Box((0,0),(π/2,π)); backend = Backend.Cubature())
     @test II.backend(J) isa Backend.Cubature   # default
     @test J() ≈ -2
     @test J(2; λ = 2, σ = 1) ≈ 1.4803924093
-
-    # 1D version
-    J = Integral(exp, Domain.Box(0,1); backend = Backend.Cubature())
-    @test II.backend(J) isa Backend.Cubature
-    @test J() ≈ exp(1) - 1
 
     # witherror
     value, error = witherror(J, 2; λ = 2, σ = 1)


### PR DESCRIPTION
For 1D we need to call `hquadrature` not `hcubature`