### PR TITLE
Bugfix: unbounded 1D domains with HCubature and Cubature backends

### DIFF
--- a/ext/IntegrationInterfaceCubatureExt.jl
+++ b/ext/IntegrationInterfaceCubatureExt.jl
@@ -42,6 +42,7 @@ hquadrature_or_hcubature(args...; kw...) = hcubature(args...; kw...)
 ensure_real(x::Real) = x
 ensure_real(_) = throw(ArgumentError("Cubature doesn't understand non-real functions. You can try with a mutating complex-vector-valued function."))
 
+error_if_Inf(s::Domain.Box{1}) = error_if_Inf(first(s)) || error_if_Inf(last(s)) || s
 error_if_Inf(s::Domain.Box) = any(error_if_Inf, first(s)) || any(error_if_Inf, last(s)) || s
 error_if_Inf(x::Number) = isinf(x) &&
     throw(ArgumentError("Cubature doesn't understand domains with `Inf`s. Use `Infinity(point)` instead."))

--- a/ext/IntegrationInterfaceCubatureExt.jl
+++ b/ext/IntegrationInterfaceCubatureExt.jl
@@ -42,8 +42,8 @@ hquadrature_or_hcubature(args...; kw...) = hcubature(args...; kw...)
 ensure_real(x::Real) = x
 ensure_real(_) = throw(ArgumentError("Cubature doesn't understand non-real functions. You can try with a mutating complex-vector-valued function."))
 
-error_if_Inf(s::Domain.Box{1}) = error_if_Inf(first(s)) || error_if_Inf(last(s)) || s
-error_if_Inf(s::Domain.Box) = any(error_if_Inf, first(s)) || any(error_if_Inf, last(s)) || s
+error_if_Inf(s::Domain.Box) = error_if_Inf(first(s)) || error_if_Inf(last(s)) || s
+error_if_Inf(x) = any(error_if_Inf, x)
 error_if_Inf(x::Number) = isinf(x) &&
     throw(ArgumentError("Cubature doesn't understand domains with `Inf`s. Use `Infinity(point)` instead."))
 error_if_Inf(x::Infinity) = false

--- a/ext/IntegrationInterfaceHCubatureExt.jl
+++ b/ext/IntegrationInterfaceHCubatureExt.jl
@@ -19,6 +19,7 @@ II.convert_integrand(::II.Integral{<:Any}, ::Backend.HCubature, domain, args; kw
 hquadrature_or_hcubature(f, min::Number, max::Number; kw...) = hquadrature(f, min, max; kw...)
 hquadrature_or_hcubature(args...; kw...) = hcubature(args...; kw...)
 
+error_if_Inf(s::Domain.Box{1}) = error_if_Inf(first(s)) || error_if_Inf(last(s)) || s
 error_if_Inf(s::Domain.Box) = any(error_if_Inf, first(s)) || any(error_if_Inf, last(s)) || s
 error_if_Inf(x::Number) = isinf(x) &&
     throw(ArgumentError("HCubature doesn't understand domains with `Inf`s. Use `Infinity(point)` instead."))

--- a/ext/IntegrationInterfaceHCubatureExt.jl
+++ b/ext/IntegrationInterfaceHCubatureExt.jl
@@ -19,8 +19,8 @@ II.convert_integrand(::II.Integral{<:Any}, ::Backend.HCubature, domain, args; kw
 hquadrature_or_hcubature(f, min::Number, max::Number; kw...) = hquadrature(f, min, max; kw...)
 hquadrature_or_hcubature(args...; kw...) = hcubature(args...; kw...)
 
-error_if_Inf(s::Domain.Box{1}) = error_if_Inf(first(s)) || error_if_Inf(last(s)) || s
-error_if_Inf(s::Domain.Box) = any(error_if_Inf, first(s)) || any(error_if_Inf, last(s)) || s
+error_if_Inf(s::Domain.Box) = error_if_Inf(first(s)) || error_if_Inf(last(s)) || s
+error_if_Inf(x) = any(error_if_Inf, x)
 error_if_Inf(x::Number) = isinf(x) &&
     throw(ArgumentError("HCubature doesn't understand domains with `Inf`s. Use `Infinity(point)` instead."))
 error_if_Inf(x::Infinity) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,10 @@ end
     J = Integral(exp, Domain.Box(0,1); backend = Backend.HCubature())
     @test II.backend(J) isa Backend.HCubature
     @test J() ≈ exp(1) - 1
+    J = Integral(exp, Domain.Box(-Infinity(1),0); backend = Backend.HCubature())
+    @test J() ≈ 1
+    J = Integral(x->exp(-abs(x)), Domain.Box(-Infinity(1),Infinity(1)); backend = Backend.HCubature())
+    @test J() ≈ 2
 
     f(x, y) = cos(x+y)
     f(x, y, p; σ = 2, λ = 0) = (cos(x+p*y)+λ)*exp(-(x^2+(p*y)^2)/(2*σ^2))
@@ -186,6 +190,10 @@ end
     J = Integral(exp, Domain.Box(0,1); backend = Backend.Cubature())
     @test II.backend(J) isa Backend.Cubature
     @test J() ≈ exp(1) - 1
+    J = Integral(exp, Domain.Box(-Infinity(1),0); backend = Backend.Cubature())
+    @test J() ≈ 1
+    J = Integral(x->exp(-abs(x)), Domain.Box(-Infinity(1),Infinity(1)); backend = Backend.Cubature())
+    @test J() ≈ 2
 
     f(x, y) = cos(x+y)
     f(x, y, p; σ = 2, λ = 0) = (cos(x+p*y)+λ)*exp(-(x^2+(p*y)^2)/(2*σ^2))


### PR DESCRIPTION
Bugfix in the unbounded case for #49 